### PR TITLE
Fixed ingress.yaml

### DIFF
--- a/helm/go-web-app-chart/templates/ingress.yaml
+++ b/helm/go-web-app-chart/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
+  ingressClassName: nginx
   rules:
   - host: go-web-app.local
     http:
@@ -16,5 +17,4 @@ spec:
           service:
             name: go-web-app
             port:
-              number: 80
-
+              number: 8080


### PR DESCRIPTION
Issue 1: Missing Ingress Class
Ingress does not have an IngressClass defined. Due to this Nginx not handling the request properly.
Fix: Added an Ingress Class >> ingressClassName: nginx

Issue 2: Service is Listening on Port 8080, but Ingress is Forwarding to 80
Fix: Update Ingress Backend Port 80 to 8080.